### PR TITLE
Add -p (plain) flag to omit "v" prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Now the patch has been bumped, since a beta version is considered to be lower th
 
 Semtag doesn't tag if there are no new commits since the last version, or if there are unstaged changes. To force to tag, use the `-f` flag, then it will bump no matter if there are unstaged changes or no new commits.
 
+### Version prefix
+
+By default, semtag prefixes new versions with `v`. Use the `-p` (plain) flag which to create new versions with no `v` prefix.
+
 License
 =======
     Copyright 2020 Nico Hormazábal

--- a/semtag
+++ b/semtag
@@ -15,6 +15,7 @@ hasversiontag="false"
 scope="patch"
 displayonly="false"
 forcetag="false"
+prefix="v"
 forcedversion=
 versionname=
 identifier=
@@ -42,6 +43,7 @@ Options:
                in the format X.Y.Z where X, Y and Z are positive integers.
   -o         Output the version only, shows the bumped version, but doesn't tag.
   -f         Forces to tag, even if there are unstaged or uncommited changes.
+  -p         Use a plain version, ie. do not prefix with 'v'.
 Commands:
   --help     Print this help message.
   --version  Prints the program's version.
@@ -65,7 +67,7 @@ ACTION="$1"
 shift
 
 # We get the parameters
-while getopts "v:s:of" opt; do
+while getopts "v:s:ofp" opt; do
   case $opt in
     v)
       forcedversion="$OPTARG"
@@ -78,6 +80,9 @@ while getopts "v:s:of" opt; do
       ;;
     f)
       forcetag="true"
+      ;;
+    p)
+      prefix=""
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -383,7 +388,7 @@ function get_next_version {
     ;;
   esac
 
-  eval "$__result=v${__exploded[0]}.${__exploded[1]}.${__exploded[2]}"
+  eval "$__result=${prefix}${__exploded[0]}.${__exploded[1]}.${__exploded[2]}"
 }
 
 function bump_version {
@@ -401,7 +406,7 @@ function bump_version {
     explode_identifier ${__explodedlast[3]} __idlast
 
     # We get the last, given the desired id based on the scope
-    __candidatefromlast="v${__explodedlast[0]}.${__explodedlast[1]}.${__explodedlast[2]}"
+    __candidatefromlast="${prefix}${__explodedlast[0]}.${__explodedlast[1]}.${__explodedlast[2]}"
     if [[ -n "$identifier" ]]; then
       local __nextid="$identifier.1"
       if [ "$identifier" == "${__idlast[0]}" ]; then


### PR DESCRIPTION
Add an option to generate plain version strings with no `v` prefix, eg. `1.2.3` instead of `v1.2.3`