### PR TITLE
Add --merged to git tag. Cut branch name if too long.

### DIFF
--- a/semtag
+++ b/semtag
@@ -7,6 +7,9 @@ SEMVER_REGEX="^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-
 IDENTIFIER_REGEX="^\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$"
 NUMERIC_REGEX='^[0-9]+$'
 
+# Length limit for the branch name in build metadata.
+MAX_BRANCH_LENGTH=50
+
 # Global variables
 FIRST_VERSION="v0.0.0"
 finalversion=$FIRST_VERSION
@@ -615,7 +618,7 @@ function get_current {
     eval "$1=$lastversion"
   else
     local __buildinfo="$(git rev-parse --short HEAD)"
-    local __currentbranch="$(git rev-parse --abbrev-ref HEAD)"
+    local __currentbranch="$(git rev-parse --abbrev-ref HEAD | cut -c1-$MAX_BRANCH_LENGTH)"
     if [ "$__currentbranch" != "master" ]; then
       __buildinfo="$__currentbranch.$__buildinfo"
     fi
@@ -648,8 +651,7 @@ function get_current {
 }
 
 function init {
-  git fetch > /dev/null
-  TAGS="$(git tag)"
+  TAGS="$(git tag --merged)"
   IFS=$'\n' read -rd '' -a TAG_ARRAY <<<"$TAGS"
 
   get_latest ${TAG_ARRAY[@]}


### PR DESCRIPTION
I did some changes for our internal version of semtag and wanted to share them here in case they are helpful.

I added `--merged` to `git tag` because semtag was not behaving as expected when dealing with hotfix branches in our Gitflow Workflow. Given this change, I think there is no longer a need for calling `git fetch` since only merged tags (which should be available locally) are relevant for determining the version.

I also implemented functionality to shorten long branch names to keep the versions from becoming too long. This is useful, for example, when using semtag in Docker image tags which are limited to 128 chars.

Here is bash script to reproduce verify the new functionality. It should be placed and run in an empty directory:
```bash
# Assert that directory is empty
if [ "$(ls -A .)" ]
then
    echo "Directory is not empty. Aborting test."
    exit 1
fi

SEMTAG_PATH="../semtag/semtag"

# Initialize git 
git init
echo "master"  >> master.txt
git add -A && git commit -m "Initial commit"

$SEMTAG_PATH final -s minor
# Should be 0.1.0

git checkout -b develop

# Create feature_1
echo "feature_1"  >> feature1.txt
git add -A && git commit -m "Added feature_1"

$SEMTAG_PATH getcurrent
# Should be v0.1.1-dev.1+<build_info>

# Tag pre-release
$SEMTAG_PATH alpha -s minor
# Should be v0.2.0-alpha.1

# Create feature_2
echo "feature_2"  >> feature2.txt
git add -A && git commit -m "Added feature_2"

$SEMTAG_PATH getcurrent
# Should be v0.2.0-alpha.1.1+<build_info>

# Create hotfix
git checkout master
echo "hotfix"  >> hotfix.txt
git add -A && git commit -m "Added hotfix"

$SEMTAG_PATH getcurrent
# Should be v0.1.1-dev.1+<build_info>
# NOTE: This is not the case currently: v0.2.0-alpha.1.1+<build_info>

# Tag patch
$SEMTAG_PATH final -s patch
# Should be v0.1.1
# NOTE: This is not the case currently: v0.2.0

git checkout develop
$SEMTAG_PATH getcurrent
# Should *still* be v0.2.0-alpha.1.1+<build_info>
# NOTE: This is not the case currently v0.2.1-dev.2+<build_info>

# Test for branch name shortening
git checkout -b a_very_long_branch_name_just_completely_unwieldy_bordering_on_the_ridiculous
$SEMTAG_PATH getcurrent
# Branch name should be a_very_long_branch_name_just_completely_unwieldy_
```