### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Starts from version `0.0.0`, so the first time you initialize a version, it will
 Use the script as follows:
 
 ```
-$ semtag <commdand> <options>
+$ semtag <command> <options>
 ```
 
 Info commands:


### PR DESCRIPTION
Just a minor typo in README I noticed. :)

commdand -> command
