### PR TITLE
Add Custom Tag Prefix Support (-P flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,42 @@ Semtag doesn't tag if there are no new commits since the last version, or if the
 
 By default, semtag prefixes new versions with `v`. Use the `-p` (plain) flag to create new versions with no `v` prefix.
 
+### Tag prefix
+
+For projects managing multiple components in a single repository, you can use custom tag prefixes to organize versions independently. Use the `-P <prefix>` flag to add a custom prefix to your tags.
+
+```bash
+# Default behavior
+semtag alpha -s patch               # Creates: v0.0.1-alpha.1
+
+# With custom prefix
+semtag alpha -s patch -P service    # Creates: service-v0.0.1-alpha.1
+
+# Combine with -p flag for plain versions (no 'v')
+semtag alpha -s patch -P api -p     # Creates: api-0.0.1-alpha.1
+```
+
+Each tag prefix maintains its own independent version sequence, allowing you to version multiple components separately:
+
+```bash
+# Version the backend service
+semtag final -s minor -P backend    # Creates: backend-v0.1.0
+
+# Version the frontend independently
+semtag final -s patch -P frontend   # Creates: frontend-v0.0.1
+
+# Default tags remain separate
+semtag final -s major               # Creates: v1.0.0
+```
+
+Query versions by prefix:
+
+```bash
+semtag getlast -P backend           # Returns: backend-v0.1.0
+semtag getfinal -P frontend         # Returns: frontend-v0.0.1
+semtag getlast                      # Returns: v1.0.0
+```
+
 License
 =======
 

--- a/semtag
+++ b/semtag
@@ -37,6 +37,7 @@ scope="patch"
 displayonly="false"
 forcetag="false"
 prefix="v"
+tag_prefix=""
 forcedversion=
 versionname=
 identifier=
@@ -65,6 +66,7 @@ Options:
   -o         Output the version only, shows the bumped version, but doesn't tag.
   -f         Forces to tag, even if there are unstaged or uncommited changes.
   -p         Use a plain version, ie. do not prefix with 'v'.
+  -P         Add a custom prefix to the tag (e.g., -P service generates service-v0.0.1).
 Commands:
   --help     Print this help message.
   --version  Prints the program's version.
@@ -105,7 +107,7 @@ if [[ $# -gt 0 ]]; then
 fi
 
 # We get the parameters
-while getopts "v:s:ofp" opt; do
+while getopts "v:s:ofpP:" opt; do
   case $opt in
     v)
       forcedversion="$OPTARG"
@@ -123,6 +125,9 @@ while getopts "v:s:ofp" opt; do
       ;;
     p)
       prefix=""
+      ;;
+    P)
+      tag_prefix="$OPTARG-"
       ;;
     \?)
       error_exit "Invalid option: -$OPTARG"
@@ -406,7 +411,7 @@ function get_latest {
       ;;
   esac
 
-  if git rev-parse -q --verify "refs/tags/$lastversion" >/dev/null 2>&1; then
+  if git rev-parse -q --verify "refs/tags/$tag_prefix$lastversion" >/dev/null 2>&1; then
     hasversiontag="true"
   else
     hasversiontag="false"
@@ -477,7 +482,7 @@ function bump_version {
   fi
 
   # Then we try to get the version based on the latest final one
-  local __candidatefromfinal=$FIRST_VERSION
+  local __candidatefromfinal
   get_next_version $finalversion $scope __candidatefromfinal
   if [[ -n "$identifier" ]]; then
     __candidatefromfinal="$__candidatefromfinal-$identifier.1"
@@ -520,6 +525,9 @@ function increase_version {
     __version="$forcedversion"
   fi
 
+  # Add the tag_prefix to the final version for output or tagging
+  __version="${tag_prefix}${__version}"
+
   if [ "$displayonly" == "true" ]; then
     echo "$__version"
   else
@@ -532,8 +540,8 @@ function increase_version {
         error_exit "Failed to get git commit log"
       fi
     else
-      if ! __commitlist=$(git log --pretty=oneline "$finalversion"... 2>/dev/null); then
-        error_exit "Failed to get git commit log from $finalversion"
+      if ! __commitlist=$(git log --pretty=oneline "$tag_prefix$finalversion"... 2>/dev/null); then
+        error_exit "Failed to get git commit log from $tag_prefix$finalversion"
       fi
     fi
 
@@ -677,7 +685,7 @@ function get_scope_auto {
   local __scope=""
 
   get_total_lines __total
-  get_sincetag_lines "$finalversion" __since
+  get_sincetag_lines "$tag_prefix$finalversion" __since
 
   local __percentage=0
   if [ "${__total[0]}" != "0" ]; then
@@ -721,8 +729,8 @@ function get_current {
   local __commitcount
 
   if [ "$hasversiontag" == "true" ]; then
-    if ! __commitcount=$(git rev-list "$lastversion".. --count 2>/dev/null); then
-      error_exit "Failed to get commit count from $lastversion"
+    if ! __commitcount=$(git rev-list "$tag_prefix$lastversion".. --count 2>/dev/null); then
+      error_exit "Failed to get commit count from $tag_prefix$lastversion"
     fi
   else
     if ! __commitcount=$(git rev-list --count HEAD 2>/dev/null); then
@@ -796,7 +804,23 @@ function init {
     TAG_ARRAY=()
   fi
 
-  get_latest "${TAG_ARRAY[@]}"
+  # Filter and strip tag_prefix from tags
+  local FILTERED_TAGS=()
+  if [[ ${#TAG_ARRAY[@]} -gt 0 ]]; then
+    for tag in "${TAG_ARRAY[@]}"; do
+      if [[ "$tag" == "$tag_prefix"* ]]; then
+        # Strip the tag_prefix from the tag
+        local stripped_tag="${tag#$tag_prefix}"
+        FILTERED_TAGS+=("$stripped_tag")
+      fi
+    done
+  fi
+
+  if [[ ${#FILTERED_TAGS[@]} -gt 0 ]]; then
+    get_latest "${FILTERED_TAGS[@]}"
+  else
+    get_latest
+  fi
 
   if ! currentbranch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); then
     error_exit "Failed to get current git branch"
@@ -837,11 +861,11 @@ case "$ACTION" in
     ;;
   getlast)
     init
-    echo "$lastversion"
+    echo "$tag_prefix$lastversion"
     ;;
   getfinal)
     init
-    echo "$finalversion"
+    echo "$tag_prefix$finalversion"
     ;;
   getcurrent)
     init
@@ -851,8 +875,8 @@ case "$ACTION" in
     ;;
   get)
     init
-    echo "Current final version: $finalversion"
-    echo "Last tagged version:   $lastversion"
+    echo "Current final version: $tag_prefix$finalversion"
+    echo "Last tagged version:   $tag_prefix$lastversion"
     ;;
   *)
     error_exit "'$ACTION' is not a valid command, see --help for available commands."


### PR DESCRIPTION
Adds a new `-P` flag to support custom tag prefixes, enabling independent version tracking for multiple components in a single repository. Fully backwards compatible, current functionality remains unchanged if no `-P` is specified.

### Usage
```bash
# Create tags with custom prefix
semtag alpha -s patch -P service    # Creates: service-v0.0.1-alpha.1

# Combine with -p for plain versions
semtag alpha -s patch -P api -p     # Creates: api-0.0.1-alpha.1

# Query by prefix
semtag getlast -P service           # Returns: service-v0.0.1-alpha.1

# Default behavior unchanged
semtag alpha -s patch               # Creates: v0.0.1-alpha.1
```

### Use Cases

This feature is really useful for repositories with multiple components (e.g. helm charts repos with multiple charts) that require independent versioning or managing different release tracks in the same codebase.

I saw this was already attempted in #8 but I'd like to give it another shot. I needed this functionality anyways so maybe other people find it useful as well.

### Changes
- Added `tag_prefix` variable and `-P <prefix>` flag to specify custom tag prefixes
- Tags now support format: `<custom-prefix>-<version>` (e.g., `service-v0.0.1`)
- Updated tag filtering to only process tags matching the current prefix
- Modified all git operations to use `tag_prefix` when referencing tags
- Updated help text and README with `-P` flag documentation

### Implementation Details

- tag_prefix variable: Controls custom tag prefix (empty by default, set with -P)
- The tag prefix logic is handled outside of the semantic versioning handlers. 
- Each tag prefix maintains completely independent version sequences
- Full backward compatibility maintained. All existing functionality remains unchanged

### Testing

Tried my best at testing the different scenarios:

- ✅ Default versioning (v prefix)
- ✅ Plain versioning (-p flag)
- ✅ Custom prefix versioning (-P flag)
- ✅ Combined flags (-P with -p)
- ✅ Independent version tracking per prefix
- ✅ All commands: final, alpha, beta, candidate, get, getlast, getfinal
